### PR TITLE
Add dependencies to package.json and gulp pipeline.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -39,6 +39,10 @@ function modules() {
       '!./node_modules/jquery/dist/core.js'
     ])
     .pipe(gulp.dest('./vendor/jquery'));
+  var jqueryEasing = gulp.src('./node_modules/jquery-easing/dist/**/*')
+    .pipe(gulp.dest('./vendor/jquery-easing'));
+  var select2 = gulp.src('./node_modules/select2/dist/**/*')
+    .pipe(gulp.dest('./vendor/select2'));
   return merge(bootstrap, jquery);
 }
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "title": "Maine Food Support Services",
     "name": "maine-food-support-services",
-    "version": "5.1.1",
+    "version": "5.1.2",
     "scripts": {
         "start": "node_modules/.bin/gulp watch"
     },
@@ -11,7 +11,9 @@
     },
     "dependencies": {
         "bootstrap": "4.3.1",
-        "jquery": "3.4.1"
+        "jquery": "3.4.1",
+        "jquery-easing": "0.0.1",
+        "select2": "4.0.13"
     },
     "devDependencies": {
         "browser-sync": "2.26.7",


### PR DESCRIPTION
Add jquery-easing and select2 to package.json and gulpfile, so that they are packaged and copied in a similar fashion to bootstrap and jquery.

Without these settings, running `npm run start` wipes out the files committed to the repository, and the map page is non-functional.

Fixes #23