### PR TITLE
Accessibility improvements for map page

### DIFF
--- a/css/home.css
+++ b/css/home.css
@@ -1,5 +1,5 @@
 #home {
-    background: linear-gradient(0deg,  rgba(9,9,121,.9) 0%, rgba(0, 123, 255, 1) 100%);
+    background: linear-gradient(0deg,  rgba(9,9,121,.9) 0%, #0063cc 100%);
 }
 
 #home-footer {
@@ -7,13 +7,13 @@
 }
 
 #hero-tagline {
-    color: rgba(255, 255, 255, .65);
+    color: rgba(255, 255, 255, .85);
 }
 #hero-tagline > a {
-    color: rgba(255, 255, 255, .65);
+    color: rgba(255, 255, 255, .85);
 }
 #hero-tagline > a:hover {
-    color: rgba(255, 255, 255, .95);
+    color: rgb(255, 255, 255);
 }
 
 #filter-container {
@@ -41,7 +41,7 @@
 .toggle-label {
     display: block; 
     margin-top: -8px; 
-    color: #f0f0f0;
+    color: #ffffff;
     font-size: 12px;
     font-weight: bold;
 }
@@ -58,17 +58,12 @@
     font-weight: 500;
     font-size: 20px;
 }
-.resource-description {
-    margin-bottom: 6px;
-}
-.resource-link>a{
-    font-size: 18px;
+.resource-header>a{
     display: flex;
     align-items: center;
 }
-.resource-link>a:hover {
-    text-decoration: none;
-    
+.resource-description {
+    margin-bottom: 6px;
 }
 
 @media (max-width: 768px) {

--- a/css/map.css
+++ b/css/map.css
@@ -94,12 +94,12 @@
 }
 .toggle-icon {
   font-size: 32px !important;
-  color: orange;
+  color: #ffab0f;
 }
 .toggle-label {
   display: block; 
   margin-top: -8px; 
-  color: burlywood;
+  color: #f4e7d7;
   font-size: 12px;
   font-weight: bold;
 }

--- a/css/shared.css
+++ b/css/shared.css
@@ -64,6 +64,10 @@ label {
   width: 100%;
 }
 
+.badge.badge-info {
+  background-color: #117888;
+}
+
 /* select2 overrides */
 .select2-container--default .select2-selection--multiple .select2-selection__choice__remove,
 .select2-container--default .select2-selection--single .select2-selection__placeholder {

--- a/css/shared.css
+++ b/css/shared.css
@@ -27,7 +27,7 @@ body {
 }
 
 .navbar-custom {
-    background-color: #323272!important;
+    background-color: #323272;
     padding-top: 0.25rem;
     padding-bottom: 0.25rem;
     -webkit-box-shadow: 0 0 5px 0 rgba(50, 50, 50, 0.75);
@@ -40,6 +40,35 @@ body {
     font-weight: 400;
     margin-left: 1rem;
 }
+
+/* Begin accessibility tweaks to theme */
+.navbar-dark.navbar-custom .navbar-nav .nav-link {
+  color: rgba(255, 255, 255, 0.75);
+}
+
+a {
+  color: #0063cc;
+}
+
+/* Bootstrap overrides */
+.btn-primary {
+  background-color: #0063cc;
+  border-color: #0063cc;
+}
+
+.text-muted {
+  color: #5f666d !important;
+}
+
+label {
+  width: 100%;
+}
+
+/* select2 overrides */
+.select2-container--default .select2-selection--multiple .select2-selection__choice__remove {
+  color: #666666;
+}
+/* End accessibility tweaks to theme */
 
 .select2-container {
     width: 100%!important;

--- a/css/shared.css
+++ b/css/shared.css
@@ -65,7 +65,8 @@ label {
 }
 
 /* select2 overrides */
-.select2-container--default .select2-selection--multiple .select2-selection__choice__remove {
+.select2-container--default .select2-selection--multiple .select2-selection__choice__remove,
+.select2-container--default .select2-selection--single .select2-selection__placeholder {
   color: #666666;
 }
 /* End accessibility tweaks to theme */

--- a/index.html
+++ b/index.html
@@ -39,7 +39,7 @@
     </div>
   </nav>
 
-  <div id="page-content">
+  <main id="page-content">
     <!-- Header -->
     <header class="py-5 mb-5" id="home">
       <div class="container h-100">
@@ -66,34 +66,37 @@
             <form  id="search-form" class="mt-3">
               <div class="row mb-5 d-flex align-items-center">
                 <div class="col-sm-6 col-7 mb-3 ">
-                  <label for="zip-code"><strong>Zip code</strong></label>
-                  <input required pattern="^([0-9]{5})\s*[-]?\s*([0-9]{4})?\s*$" 
-                         minlength="5" maxlength="10" 
-                         type="text" class="form-control" 
-                         id="zip-code" name="zip-code" 
-                         aria-describedby="hero-zip-help" 
-                         placeholder="Use format 12345">
+                  <label for="zip-code"><strong>Zip code</strong>
+                    <input required pattern="^([0-9]{5})\s*[-]?\s*([0-9]{4})?\s*$" 
+                           minlength="5" maxlength="10" 
+                           type="text" class="form-control" 
+                           id="zip-code" name="zip-code" 
+                           aria-describedby="hero-zip-help" 
+                           placeholder="Use format 12345">
+                  </label>
                   <small id="hero-zip-help" class="form-text text-muted">Enter a Maine zip code</small>
                 </div>
     
                 <div class="col-sm-6 col-5 mb-3">
-                  <label for="radius-select"><strong>Search radius</strong></label>
-                  <select size="1" required class="custom-select form-control select-default" id="radius-select" aria-describedby="hero-radius-help">
-                    <option value=10>10</option>
-                    <option value=20>20</option>
-                    <option value=30>30</option>
-                    <option value=50>50</option>
-                  </select>
+                  <label for="radius-select"><strong>Search radius</strong>
+                    <select size="1" required class="custom-select form-control select-default" id="radius-select" aria-describedby="hero-radius-help">
+                      <option value=10>10</option>
+                      <option value=20>20</option>
+                      <option value=30>30</option>
+                      <option value=50>50</option>
+                    </select>
+                  </label>
                   <small id="hero-radius-help" class="form-text text-muted">Miles from zip code</small>
                 </div>
                 <div class="col-12">
-                  <label for="category-select"><strong>Categories</strong></label>
-                  <select required class="custom-select select-default" 
-                    aria-describedby="hero-category-help"
-                    id="category-select"               
-                    name="category-select[]"
-                    multiple="multiple">
-                  </select>
+                  <label for="category-select"><strong>Categories</strong>
+                    <select required class="custom-select select-default" 
+                      aria-describedby="hero-category-help"
+                      id="category-select"               
+                      name="category-select[]"
+                      multiple="multiple">
+                    </select>
+                  </label>
                   <small id="hero-category-help" class="form-text text-muted">Select one or more categories</small>
                 </div>
               </div>
@@ -106,7 +109,7 @@
     </header>
     
     <!-- Mission statement -->
-    <div class="container" id="mission">
+    <section class="container" id="mission">
       <div class="row mb-5 mt-5">
         <div class="col-12">
           <h2 id="mission-title" class="text-dark">
@@ -141,12 +144,12 @@
           </div>
         </div>
         <div class="col-sm-5">
-          <img class="img-thumbnail" alt="apples" src="images/apple_red.jfif"/>
+          <img class="img-thumbnail" src="images/apple_red.jfif" alt="Dripping wet red apples"/>
         </div>
       </div>
-    </div>
+    </section>
     <!-- About the data -->
-    <div class="container" id="about">
+    <section class="container" id="about">
       <div class="row mb-5 mt-5">
         <div class="col-12">
           <h2 id="data-title" class="text-dark">
@@ -164,12 +167,12 @@
           </div>
         </div>
         <div class="col-sm-5">
-          <img class="img-thumbnail" alt="vegetables" src="images/produce.jpg"/>
+          <img class="img-thumbnail" src="images/produce.jpg" alt="Stacks of vegetables"/>
         </div>
       </div>
-    </div>
+    </section>
     <!-- Other resources -->
-    <div class="container" id="other-resources">
+    <section class="container" id="other-resources">
       <div class="row mb-5 mt-5">
         <div class="col-12">
           <h2 id="other-resources-title" class="text-dark">Other Resources</h2>
@@ -178,55 +181,50 @@
         <div class="col-12">
           <div class="row" id="other-resources-text">
             <div class="col-12 resource-container" style="padding-top: 0;">
-              <div class="resource-header">Good Shepherd Food Bank</div>
-              <div class="resource-description">Good Shepherd Food Bank and its network of 450+ agency partners — including food pantries and meal sites — is the largest hunger-relief organization in Maine</div>
-              <div class="resource-link">
-                <a href="https://www.gsfb.org/" title="Good Shepherd Food Bank Website" target="_blank" rel="noopener">
-                  View Website 
-                 <i class="material-icons ml-1" title="open website">launch</i>
-                </a>
-              </div>
-            </div>
-            <div class="col-12 resource-container">
-              <div class="resource-header">2-1-1 Maine</div>
-              <div class="resource-description">Information about Maine food pantries, meal sites, senior dining sites, and more.</div>
-              <div class="resource-link">
-                <a href="https://211maine.org/" title="2-1-1 Maine Website" target="_blank" rel="noopener">
-                  View Website
+              <div class="resource-header">
+                <a href="https://www.gsfb.org/" alt="Good Shepherd Food Bank Website" target="_blank" rel="noopener">
+                  Good Shepherd Food Bank
                   <i class="material-icons ml-1" title="open website">launch</i>
                 </a>
               </div>
+              <div class="resource-description">Good Shepherd Food Bank and its network of 450+ agency partners — including food pantries and meal sites — is the largest hunger-relief organization in Maine</div>
             </div>
             <div class="col-12 resource-container">
-              <div class="resource-header">Wayside Food Programs</div>
-              <div class="resource-description">A list of community resources available, including food pantries and meals (breakfast & lunch) for youth up to age 18.</div>
-              <div class="resource-link">
-                <a href="https://waysidemaine.org/community-resources" title="Wayside Maine Website" target="_blank" rel="noopener">
-                  View Website 
-                 <i class="material-icons ml-1" title="open website">launch</i>
+              <div class="resource-header">
+                <a href="https://211maine.org/" alt="2-1-1 Maine Website" target="_blank" rel="noopener">
+                  2-1-1 Maine
+                  <i class="material-icons ml-1" title="open website">launch</i>
                 </a>
               </div>
+              <div class="resource-description">Information about Maine food pantries, meal sites, senior dining sites, and more.</div>
+            </div>
+            <div class="col-12 resource-container">
+              <div class="resource-header">
+                <a href="https://waysidemaine.org/community-resources" alt="Wayside Maine Website" target="_blank" rel="noopener">
+                  Wayside Food Programs
+                  <i class="material-icons ml-1" title="open website">launch</i>
+              </a>
+              <div class="resource-description">A list of community resources available, including food pantries and meals (breakfast &amp; lunch) for youth up to age 18.</div>
             </div>
 
             <div class="col-12 resource-container">
-              <div class="resource-header">The Emergency Food Assistance Program</div>
+              <div class="resource-header">
+                <a href="https://www.maine.gov/dacf/ard/tefap/bytown.shtml" alt="Visit The Emergency Food Assistance Program website" target="_blank" rel="noopener">
+                  The Emergency Food Assistance Program
+                  <i class="material-icons ml-1" title="open website">launch</i>
+                </a>
+              </div>
               <div class="resource-description">
                 The Emergency Food Assistance Program (TEFAP) is a federal program that helps supplement the diets of low-income Americans by providing them with emergency food assistance at no cost. 
-              </div>
-              <div class="resource-link">
-                <a href="https://www.maine.gov/dacf/ard/tefap/bytown.shtml" title="Visit The Emergency Food Assistance Program website" target="_blank" rel="noopener">
-                  View Website 
-                 <i class="material-icons ml-1" title="open website">launch</i>
-                </a>
               </div>
             </div>
           </div>
         </div>
       </div>
-    </div>
+    </section>
 
     <!-- Contact and social media -->
-    <div class="container mt-2" id="contact">
+    <section class="container mt-2" id="contact">
       <div class="row mb-5">
         <div class="col-12">
           <h2 id="contact-title" class="text-dark">
@@ -244,11 +242,11 @@
           <div class="row mt-4 text-center">
             <div class="col-md-6">
               <div class="mt-3">
-                <h4 class="h4">Email</h4>
+                <h3 class="h4">Email</h3>
                 <div>
                   <span>
-                    <span id="contact-email" class="mr-1">hello@openmaine.org</span>
                     <a href="mailto:hello@openmaine.org" target="_blank" title="Email hello@openmaine.org">
+                      <span id="contact-email" class="mr-1">hello@openmaine.org</span>
                       <i class="fa fa-envelope"></i>
                     </a>
                   </span>
@@ -256,7 +254,7 @@
               </div>
             </div>
             <div class="col-md-6 mt-3">
-              <h4 class="h4">Social Media</h4>
+              <h3 class="h4">Social Media</h3>
               <ul class="list-inline mb-0" id="social-media-icons">
                 <li class="list-inline-item">
                   <a href="https://www.facebook.com/openmaine" target="_blank" rel="noopener" title="OpenMaine Facebook">
@@ -303,9 +301,9 @@
           </div>
         </div>
       </div>
-    </div>
+    </section>
     <!-- /.about container -->
-  </div>
+  </main>
 
   <!-- Footer -->
   <footer class="py-5 bg-dark" id="home-footer">

--- a/js/map/pantryMapController.js
+++ b/js/map/pantryMapController.js
@@ -100,11 +100,11 @@ class PantryMapController {
     _setLegend() {
         let div = L.DomUtil.create('div', 'info legend');
         div.innerHTML += '<div style="background-color:white;>';
-        div.innerHTML += `<img src=${MarkerIcon.getPath(MarkerIcon.Restaurant)} /> &ndash; Meal Site <br>`;
-        div.innerHTML += `<img src=${MarkerIcon.getPath(MarkerIcon.Grocery)} /> &ndash; Food Pantry <br>`;
-        div.innerHTML += `<img src=${MarkerIcon.getPath(MarkerIcon.Home)} /> &ndash; Shelter <br>`;
-        div.innerHTML += `<img src=${MarkerIcon.getPath(MarkerIcon.DayCare)} /> &ndash; Youth Program <br>`;
-        div.innerHTML += `<img src=${MarkerIcon.getPath(MarkerIcon.Star)} /> &ndash; Other <br>`;
+        div.innerHTML += `<img src=${MarkerIcon.getPath(MarkerIcon.Restaurant)} alt="Meal Site"/> &ndash; Meal Site <br>`;
+        div.innerHTML += `<img src=${MarkerIcon.getPath(MarkerIcon.Grocery)} alt="Food Pantry"/> &ndash; Food Pantry <br>`;
+        div.innerHTML += `<img src=${MarkerIcon.getPath(MarkerIcon.Home)} alt="Shelter"/> &ndash; Shelter <br>`;
+        div.innerHTML += `<img src=${MarkerIcon.getPath(MarkerIcon.DayCare)} alt="Youth Program"/> &ndash; Youth Program <br>`;
+        div.innerHTML += `<img src=${MarkerIcon.getPath(MarkerIcon.Star)} alt="Other"/> &ndash; Other <br>`;
         div.innerHTML += '</div>'; 
         this.map.addLegend(div);
     }

--- a/map.html
+++ b/map.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="description" content="Find food pantries, meal sites, SNAP retailers, and other food resources in Maine">
   <meta name="author" content="OpenMaine Code for America Brigade">
 
@@ -26,15 +26,15 @@
 
 <body>
   <!-- Sidebar -->
-  <div class="border-right shadow-lg toggled sidebar-toggleable margin-transition" id="sidebar-wrapper">
+  <aside class="border-right shadow-lg toggled sidebar-toggleable margin-transition" id="sidebar-wrapper">
     <div class="sidebar-toggleable toggled" id="sidebar-heading"></div>
     <div id="map-list-wrapper">
       <div id="map-result-spacer"></div>
       <div id="map-results-list"></div>
     </div>
-  </div>
+  </aside>
   
-  <div class="d-flex" id="wrapper">
+  <main class="d-flex" id="wrapper">
     <div class="toggled sidebar-toggleable margin-transition hidden-lg">&nbsp;</div>
     <!-- Page Content -->
     <div id="page-content-wrapper">
@@ -58,7 +58,7 @@
       <span id="nav-mobile"></span>
     </div>
     <!-- /#page-content-wrapper -->
-  </div>
+  </main>
   <!-- /#wrapper -->
 
 
@@ -182,13 +182,15 @@
           <small class="text-muted">Clears county and town filters</small>
         </div>
         <div class="col-sm-2 col-3">
-          <label class="top-label" for="radius-select">Radius</label>
-          <select class="custom-select form-control select-default" id="radius-select" size="1" aria-describedby="hero-radius-help" required>
-            <option value=10>10</option>
-            <option value=20>20</option>
-            <option value=30>30</option>
-            <option value=50>50</option>
-          </select>
+          <label class="top-label" for="radius-select">
+            Radius
+            <select class="custom-select form-control select-default" id="radius-select" size="1" required>
+              <option value=10>10</option>
+              <option value=20>20</option>
+              <option value=30>30</option>
+              <option value=50>50</option>
+            </select>
+          </label>
           <small class="text-muted">Miles</small>
         </div>
         <div class="col-lg-2 col-sm-3 col-12" id="zip-search-button-container">
@@ -198,22 +200,25 @@
 
       <div class="row">
         <div class="col-md-5 col-sm-12 col-12">
-          <label class="top-label" for="category-select">Category</label>
-          <select class="custom-select select-default my-1 mr-sm-2" 
-                  id="category-select"               
-                  name="category-select[]"
-                  multiple="multiple">
-          </select>
+          <label class="top-label" for="category-select">Category
+            <select class="custom-select select-default my-1 mr-sm-2" 
+                    id="category-select"               
+                    name="category-select[]"
+                    multiple="multiple">
+            </select>
+          </label>
         </div>
         <div class="col-md-3 col-6">
-          <label class="top-label" for="county-select">County</label>
-          <select class="custom-select select-default my-1 mr-sm-2" id="county-select">
-          </select>
+          <label class="top-label" for="county-select">County
+            <select class="custom-select select-default my-1 mr-sm-2" id="county-select">
+            </select>
+          </label>
         </div>
         <div class="col-md-4 col-6">
-          <label class="top-label" for="town-select">Town</label>
-          <select class="custom-select select-default my-1 mr-sm-2" id="town-select">
-          </select>
+          <label class="top-label" for="town-select">Town
+            <select class="custom-select select-default my-1 mr-sm-2" id="town-select">
+            </select>
+          </label>
         </div>
       </div>
     </div>

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "title": "Maine Food Support Services",
     "name": "maine-food-support-services",
-    "version": "5.1.2",
+    "version": "5.1.3",
     "scripts": {
         "start": "node_modules/.bin/gulp watch"
     },


### PR DESCRIPTION
Evaluated and remediated many issues on the Map, including:

**Based off changes submitted in #50**

* Alt text on legend images
* Color contrast for app navigation icons
* Color contrast for app navigation links
* Color contrast for some select2 controls
* Color contrast for bootstrap `.badge-info`
* Add semantic HTML for landmark regions: main, aside
* Enclose selects within a label

A few issues cannot be remediated until libraries can accommodate:

* Select2 adds elements with `role="textbox"` without aria-labels.
* Leaflet's zoom, legend, and attribution controls cannot be fully validated, due to background imagery.

Fixes #46 