### PR TITLE
Add click-to-call feature.

### DIFF
--- a/css/map.css
+++ b/css/map.css
@@ -319,3 +319,8 @@
 .leaflet-bottom {
   z-index: 998 !important;
 }
+
+a[href^="tel:"]:before {
+  content: "\260e";
+  margin-right: 0.5em;
+}

--- a/js/core/util.js
+++ b/js/core/util.js
@@ -20,5 +20,8 @@ const Util = {
         if (value.constructor.name === "Array")
             return value.length === 0;
         return false;
-    }
+    },
+  
+    telFormat: (phone) => 
+      phone.replace(/\D/g, '').replace(/^1?/, '+1')
 }

--- a/js/handlebarsHelpers.js
+++ b/js/handlebarsHelpers.js
@@ -5,3 +5,6 @@ Handlebars.registerHelper('arr_empty', function(arr, opts) {
         return opts.inverse(this);
     }
 });
+Handlebars.registerHelper('tel', function(phone) {
+    return phone.replace(/\D/g, '').replace(/^1?/, '+1');
+});

--- a/js/map/pantryMapController.js
+++ b/js/map/pantryMapController.js
@@ -216,7 +216,7 @@ class PantryMapController {
             `<span style="font-size:1.1rem">${foodResource.Name}</span><br>`,
             `<hr style="margin-top: 0; margin-bottom: 4px;">`,
             `<small><b>Category: </b>${foodResource.Category}</small><br>`,
-            `<small><b>Phone: </b>${foodResource.Phone}</small><br>`,
+            `<small><b>Phone: </b><a href="tel:${Util.telFormat(foodResource.Phone)}">${foodResource.Phone}</a></small><br>`,
         ];
 
         if (!Util.isNullOrEmpty(foodResource.WebLink)) {

--- a/map.html
+++ b/map.html
@@ -89,7 +89,7 @@
             {{/if}}
             <div class="small">
               {{Category}} 
-              <span class="text-muted small ml-1">{{Phone}}</span>
+              <a href="tel:{{tel Phone}}" class="small ml-1">{{Phone}}</a>
             </div>
           </div>
         </div>


### PR DESCRIPTION
Telephone numbers are now clickable. Updated both the list and map popup templates to wrap numbers in basic `tel:` hrefs.

Added unicode "phone" characters before any a[tel:] links for clarity.

Fixes #52